### PR TITLE
On read of specific resources allow upsert if read fails.

### DIFF
--- a/internal/bowtie/resources/dns_block_list.go
+++ b/internal/bowtie/resources/dns_block_list.go
@@ -162,10 +162,11 @@ func (bl *dnsBlockListResource) Read(ctx context.Context, req resource.ReadReque
 
 	blocklist, err := bl.client.GetDNSBlockList(state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
+		/*resp.Diagnostics.AddInfo(
 			"Failed retrieving DNS block list",
 			"Unexpected error retrieving DNS block list from Bowtie API: "+err.Error(),
-		)
+		)*/
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/bowtie/resources/resource.go
+++ b/internal/bowtie/resources/resource.go
@@ -193,10 +193,11 @@ func (r *resourceResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	resource, err := r.client.GetResource(state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
+		/*resp.Diagnostics.AddError(
 			"Unexpected error retrieving the resource",
 			"Failed to retrieve resource: "+state.ID.ValueString()+" error: "+err.Error(),
-		)
+		)*/
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/bowtie/resources/site.go
+++ b/internal/bowtie/resources/site.go
@@ -109,10 +109,11 @@ func (s *siteResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	site, err := s.client.GetSite(state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
+		/*resp.Diagnostics.AddError(
 			"Failed retrieving site information from bowtie",
 			"Unexpected error retrieving site info from bowtie server: "+err.Error(),
-		)
+		)*/
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/bowtie/resources/site_range.go
+++ b/internal/bowtie/resources/site_range.go
@@ -176,10 +176,11 @@ func (sr *siteRangeResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	info, err := sr.client.GetSiteRange(state.SiteID.ValueString(), state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
+		/*resp.Diagnostics.AddError(
 			"Failed to retrieve site range info from the bowtie server",
 			"Unexpected error reading from the bowtie server error: "+err.Error(),
-		)
+		)*/
+		resp.State.RemoveResource(ctx)
 		return
 	}
 


### PR DESCRIPTION
This requires further iteration to sharpen the tool.

In order to prevent failure on read when a resource is deleted out of band, we mark the resource as removed instead of returning an error.

This is currently only enabled for the four resource types in use by `terraform-bowtie-control-plane` but it should be expanded more generally.

Further the error condition should probably be a bit more clever, potentially checking the exact resource for a 404 when available.