### PR TITLE
Recreate disappearing resources and honor state IDs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,4 @@ use nix
 watch_file devshell.toml flake.nix  shell.nix
 dotenv config.env
 
-export BOWTIE_HOST=http://127.0.0.1:3000
-
 source_env_if_exists .envrc.local

--- a/.envrc
+++ b/.envrc
@@ -2,4 +2,6 @@ use nix
 watch_file devshell.toml flake.nix  shell.nix
 dotenv config.env
 
+export BOWTIE_HOST=http://127.0.0.1:3000
+
 source_env_if_exists .envrc.local

--- a/internal/bowtie/client/dns.go
+++ b/internal/bowtie/client/dns.go
@@ -5,14 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/google/uuid"
 )
-
-func (c *Client) CreateDNS(name string, serverAddrs []Server, includeOnlySites []string, isDNS64, isCounted, isLog, isDropA, isDropAll, isSearchDomain bool, exlude []DNSExclude) (string, error) {
-	id := uuid.NewString()
-	return id, c.UpsertDNS(id, name, serverAddrs, includeOnlySites, isDNS64, isCounted, isLog, isDropA, isDropAll, isSearchDomain, exlude)
-}
 
 func (c *Client) UpsertDNS(id, name string, serverAddrs []Server, includeOnlySites []string, isDNS64, isCounted, isLog, isDropA, isDropAll, isSearchDomain bool, exlude []DNSExclude) error {
 	var servers map[string]Server = map[string]Server{}
@@ -62,16 +55,11 @@ func (c *Client) DeleteDNS(id string) error {
 	return err
 }
 
-func (c *Client) GetDNS(id string) (*DNS, error) {
+func (c *Client) GetDNS() (map[string]DNS, error) {
 	org, err := c.GetOrganization()
 	if err != nil {
 		return nil, err
 	}
 
-	result, ok := org.DNS[id]
-	if !ok {
-		return nil, fmt.Errorf("failed to locate the dns object")
-	}
-
-	return &result, nil
+	return org.DNS, nil
 }

--- a/internal/bowtie/client/dnsblocklist.go
+++ b/internal/bowtie/client/dnsblocklist.go
@@ -5,14 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/google/uuid"
 )
-
-func (c *Client) CreateDNSBlockList(name string, upstream string, override_to_allow string) (string, error) {
-	id := uuid.NewString()
-	return id, c.UpsertDNSBlockList(id, name, upstream, override_to_allow)
-}
 
 func (c *Client) UpsertDNSBlockList(id string, name string, upstream string, override_to_allow string) error {
 	var payload DNSBlockList = DNSBlockList{
@@ -60,19 +53,4 @@ func (c *Client) GetDNSBlockLists() (map[string]DNSBlockList, error) {
 	var dnsblocklists map[string]DNSBlockList = map[string]DNSBlockList{}
 	err = json.Unmarshal(responseBody, &dnsblocklists)
 	return dnsblocklists, err
-}
-
-func (c *Client) GetDNSBlockList(id string) (*DNSBlockList, error) {
-	blocklists, err := c.GetDNSBlockLists()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, blocklist := range blocklists {
-		if blocklist.ID == id {
-			return &blocklist, nil
-		}
-	}
-
-	return nil, fmt.Errorf("block list not found: %s", id)
 }

--- a/internal/bowtie/client/groups.go
+++ b/internal/bowtie/client/groups.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 type Group struct {
@@ -29,17 +27,13 @@ type SetUserGroupMembershipPayload struct {
 	Users []map[string]string `json:"users"`
 }
 
-func (c *Client) GetGroup(id string) (*Group, error) {
+func (c *Client) GetGroups() (map[string]Group, error) {
 	groups, err := c.ListGroups()
 	if err != nil {
 		return nil, err
 	}
 
-	group, ok := groups[id]
-	if !ok {
-		return nil, fmt.Errorf("failed to find group with id: %s", id)
-	}
-	return &group, nil
+	return groups, nil
 }
 
 func (c *Client) ListGroups() (map[string]Group, error) {
@@ -60,10 +54,6 @@ func (c *Client) ListGroups() (map[string]Group, error) {
 	}
 
 	return groups, nil
-}
-
-func (c *Client) CreateGroup(name string) (string, error) {
-	return c.UpsertGroup(uuid.NewString(), name)
 }
 
 func (c *Client) UpsertGroup(id, name string) (string, error) {

--- a/internal/bowtie/client/http.go
+++ b/internal/bowtie/client/http.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,7 +25,7 @@ type AuthPayload struct {
 
 const apiVersionPrefix = "/-net/api/v0"
 
-func NewClient(ctx context.Context, host, username, password string, lazy_auth bool) (*Client, error) {
+func NewClient(host, username, password string, lazy_auth bool) (*Client, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return nil, err

--- a/internal/bowtie/client/resources.go
+++ b/internal/bowtie/client/resources.go
@@ -2,12 +2,9 @@ package client
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/google/uuid"
 )
 
 type PoliciesEndpointResponse struct {
@@ -137,19 +134,13 @@ func (c *Client) GetPolicy(id string) (BowtiePolicy, error) {
 	return policy, nil
 }
 
-func (c *Client) GetResourceGroup(id string) (BowtieResourceGroup, error) {
+func (c *Client) GetResourceGroups() (map[string]BowtieResourceGroup, error) {
 	rp, err := c.GetPoliciesAndResources()
 	if err != nil {
-		return BowtieResourceGroup{}, nil
+		return make(map[string]BowtieResourceGroup), nil
 	}
 
-	for _, val := range rp.ResourceGroups {
-		if val.ID == id {
-			return val, nil
-		}
-	}
-
-	return BowtieResourceGroup{}, fmt.Errorf("resource_group not found")
+	return rp.ResourceGroups, nil
 }
 
 func (c *Client) GetResources() (map[string]BowtieResource, error) {
@@ -181,12 +172,7 @@ func (c *Client) DeleteResource(id string) error {
 	return err
 }
 
-func (c *Client) CreateResourceGroup(ctx context.Context, name string, resources, resource_groups []string) (string, error) {
-	id := uuid.NewString()
-	return id, c.UpsertResourceGroup(ctx, id, name, resources, resource_groups)
-}
-
-func (c *Client) UpsertResourceGroup(ctx context.Context, id, name string, resources, resource_groups []string) error {
+func (c *Client) UpsertResourceGroup(id, name string, resources, resource_groups []string) error {
 	payload := BowtieResourceGroup{
 		ID:        id,
 		Name:      name,

--- a/internal/bowtie/client/resources.go
+++ b/internal/bowtie/client/resources.go
@@ -58,13 +58,7 @@ type BowtieResourcePortCollection struct {
 	Ports []int64 `json:"ports,omitempty"`
 }
 
-func (c *Client) CreateResource(ctx context.Context, name, protocol string, ip, cidr, dns string, portRange, portCollection []int64) (string, BowtieResource, error) {
-	id := uuid.NewString()
-	resource, err := c.UpsertResource(ctx, id, name, protocol, ip, cidr, dns, portRange, portCollection)
-	return id, resource, err
-}
-
-func (c *Client) UpsertResource(ctx context.Context, id, name, protocol, ip, cidr, dns string, portRange, portCollection []int64) (BowtieResource, error) {
+func (c *Client) UpsertResource(id, name, protocol, ip, cidr, dns string, portRange, portCollection []int64) (BowtieResource, error) {
 	payload := BowtieResource{
 		ID:       id,
 		Name:     name,
@@ -158,18 +152,13 @@ func (c *Client) GetResourceGroup(id string) (BowtieResourceGroup, error) {
 	return BowtieResourceGroup{}, fmt.Errorf("resource_group not found")
 }
 
-func (c *Client) GetResource(id string) (BowtieResource, error) {
+func (c *Client) GetResources() (map[string]BowtieResource, error) {
 	rp, err := c.GetPoliciesAndResources()
 	if err != nil {
-		return BowtieResource{}, err
+		return make(map[string]BowtieResource), err
 	}
 
-	for _, val := range rp.Resources {
-		if val.ID == id {
-			return val, nil
-		}
-	}
-	return BowtieResource{}, fmt.Errorf("expected resource not found")
+	return rp.Resources, nil
 }
 
 func (c *Client) DeletePolicy(id string) error {

--- a/internal/bowtie/client/users.go
+++ b/internal/bowtie/client/users.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 type BowtieUser struct {
@@ -54,7 +52,7 @@ func (c *Client) GetUserByEmail(ctx context.Context, email string) (BowtieUser, 
 	return BowtieUser{}, fmt.Errorf("user not found")
 }
 
-func (c *Client) GetUser(ctx context.Context, id string) (BowtieUser, error) {
+func (c *Client) GetUser(id string) (BowtieUser, error) {
 	req, err := http.NewRequest(http.MethodGet, c.getHostURL(fmt.Sprintf("/user/%s", id)), nil)
 	if err != nil {
 		return BowtieUser{}, nil
@@ -100,12 +98,7 @@ func (c *Client) DisableUser(ctx context.Context, id string) error {
 	return err
 }
 
-func (c *Client) CreateUser(ctx context.Context, name, email, role string, authzPolicies, authzUsers, authzControlPlane, authzDevices, enabled bool) (string, error) {
-	id := uuid.NewString()
-	return c.UpsertUser(ctx, id, name, email, role, authzPolicies, authzUsers, authzControlPlane, authzDevices, enabled)
-}
-
-func (c *Client) UpsertUser(ctx context.Context, id, name, email, role string, authzPolicies, authzUsers, authzControlPlane, authzDevices, enabled bool) (string, error) {
+func (c *Client) UpsertUser(id, name, email, role string, authzPolicies, authzUsers, authzControlPlane, authzDevices, enabled bool) (string, error) {
 	payload := BowtieUser{
 		ID:                id,
 		Name:              name,

--- a/internal/bowtie/provider/bowtie.go
+++ b/internal/bowtie/provider/bowtie.go
@@ -150,7 +150,7 @@ func (b *BowtieProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 
-	client, err := client.NewClient(ctx, host, username, password, lazy_auth)
+	client, err := client.NewClient(host, username, password, lazy_auth)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create Bowtie API Client",

--- a/internal/bowtie/provider/testutil.go
+++ b/internal/bowtie/provider/testutil.go
@@ -9,9 +9,7 @@ const (
 	// It’s assumed that authentication is provided via the
 	// BOWTIE_USERNAME and BOWTIE_PASSWORD environment variables.
 	ProviderConfig = `
-provider "bowtie" {
-  host = "http://127.0.0.1:3000"
-}
+provider "bowtie" { }
 `
 )
 

--- a/internal/bowtie/resources/user.go
+++ b/internal/bowtie/resources/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/client"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -142,7 +143,22 @@ func (u *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	id, err := u.client.CreateUser(ctx, plan.Name.ValueString(), plan.Email.ValueString(), plan.Role.ValueString(), plan.AuthzPolicies.ValueBool(), plan.AuthzUsers.ValueBool(), plan.AuthzControlPlane.ValueBool(), plan.AuthzDevices.ValueBool(), plan.Enabled.ValueBool())
+	if plan.ID.ValueString() == "" {
+		plan.ID = types.StringValue(uuid.NewString())
+	}
+
+	_, err := u.client.UpsertUser(
+		plan.ID.ValueString(),
+		plan.Name.ValueString(),
+		plan.Email.ValueString(),
+		plan.Role.ValueString(),
+		plan.AuthzPolicies.ValueBool(),
+		plan.AuthzUsers.ValueBool(),
+		plan.AuthzControlPlane.ValueBool(),
+		plan.AuthzDevices.ValueBool(),
+		plan.Enabled.ValueBool(),
+	)
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed creating user",
@@ -150,8 +166,6 @@ func (u *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		)
 		return
 	}
-
-	plan.ID = types.StringValue(id)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -163,7 +177,7 @@ func (u *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	user, err := u.client.GetUser(ctx, state.ID.ValueString())
+	user, err := u.client.GetUser(state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed reading the user: "+state.ID.ValueString(),
@@ -192,7 +206,17 @@ func (u *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	_, err := u.client.UpsertUser(ctx, plan.ID.ValueString(), plan.Name.ValueString(), plan.Email.ValueString(), plan.Role.ValueString(), plan.AuthzPolicies.ValueBool(), plan.AuthzUsers.ValueBool(), plan.AuthzControlPlane.ValueBool(), plan.AuthzDevices.ValueBool(), plan.Enabled.ValueBool())
+	_, err := u.client.UpsertUser(
+		plan.ID.ValueString(),
+		plan.Name.ValueString(),
+		plan.Email.ValueString(),
+		plan.Role.ValueString(),
+		plan.AuthzPolicies.ValueBool(),
+		plan.AuthzUsers.ValueBool(),
+		plan.AuthzControlPlane.ValueBool(),
+		plan.AuthzDevices.ValueBool(),
+		plan.Enabled.ValueBool(),
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to update the user: "+plan.ID.ValueString(),

--- a/internal/bowtie/test/dns_block_list_test.go
+++ b/internal/bowtie/test/dns_block_list_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	resourceName = "bowtie_dns_block_list.test"
+	blresourceName = "bowtie_dns_block_list.test"
 
 	blName       = "Test DNS Block List"
 	blNameChange = "Different DNS Block List name"
@@ -27,19 +27,19 @@ func TestDNSBlockListResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Basic tests for upstream URLs
 			{
-				Config: getDNSBlockListConfig(resourceName, blName, blUrl, blOverride),
+				Config: getDNSBlockListConfig(blresourceName, blName, blUrl, blOverride),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", blName),
-					resource.TestCheckResourceAttr(resourceName, "upstream", blUrl),
-					resource.TestCheckResourceAttr(resourceName, "override_to_allow.0", blOverride[0]),
-					resource.TestCheckResourceAttr(resourceName, "override_to_allow.1", blOverride[1]),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "last_updated"),
+					resource.TestCheckResourceAttr(blresourceName, "name", blName),
+					resource.TestCheckResourceAttr(blresourceName, "upstream", blUrl),
+					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.0", blOverride[0]),
+					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.1", blOverride[1]),
+					resource.TestCheckResourceAttrSet(blresourceName, "id"),
+					resource.TestCheckResourceAttrSet(blresourceName, "last_updated"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      resourceName,
+				ResourceName:      blresourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				// The last_updated attribute does not exist in the HashiCups
@@ -48,15 +48,15 @@ func TestDNSBlockListResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: getDNSBlockListConfig(resourceName, blNameChange, blUrlChange, blOverrideChange),
+				Config: getDNSBlockListConfig(blresourceName, blNameChange, blUrlChange, blOverrideChange),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", blNameChange),
-					resource.TestCheckResourceAttr(resourceName, "upstream", blUrlChange),
-					resource.TestCheckResourceAttr(resourceName, "override_to_allow.0", blOverrideChange[0]),
-					resource.TestCheckResourceAttr(resourceName, "override_to_allow.1", blOverrideChange[1]),
-					resource.TestCheckResourceAttr(resourceName, "override_to_allow.2", blOverrideChange[2]),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "last_updated"),
+					resource.TestCheckResourceAttr(blresourceName, "name", blNameChange),
+					resource.TestCheckResourceAttr(blresourceName, "upstream", blUrlChange),
+					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.0", blOverrideChange[0]),
+					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.1", blOverrideChange[1]),
+					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.2", blOverrideChange[2]),
+					resource.TestCheckResourceAttrSet(blresourceName, "id"),
+					resource.TestCheckResourceAttrSet(blresourceName, "last_updated"),
 				),
 			},
 		},

--- a/internal/bowtie/test/dns_block_list_test.go
+++ b/internal/bowtie/test/dns_block_list_test.go
@@ -80,7 +80,7 @@ func deleteDNSBlockListResources() {
 	// Pretty simple blanket statement to just remove everything.
 	blocklists, _ := client.GetDNSBlockLists()
 	for id := range blocklists {
-		client.DeleteDNSBlockList(id)
+		_ = client.DeleteDNSBlockList(id)
 	}
 }
 

--- a/internal/bowtie/test/dns_block_list_test.go
+++ b/internal/bowtie/test/dns_block_list_test.go
@@ -6,11 +6,12 @@ import (
 	"text/template"
 
 	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 const (
-	blresourceName = "bowtie_dns_block_list.test"
+	blResourceName = "bowtie_dns_block_list.test"
 
 	blName       = "Test DNS Block List"
 	blNameChange = "Different DNS Block List name"
@@ -27,19 +28,19 @@ func TestDNSBlockListResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Basic tests for upstream URLs
 			{
-				Config: getDNSBlockListConfig(blresourceName, blName, blUrl, blOverride),
+				Config: getDNSBlockListConfig(blResourceName, blName, blUrl, blOverride),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(blresourceName, "name", blName),
-					resource.TestCheckResourceAttr(blresourceName, "upstream", blUrl),
-					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.0", blOverride[0]),
-					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.1", blOverride[1]),
-					resource.TestCheckResourceAttrSet(blresourceName, "id"),
-					resource.TestCheckResourceAttrSet(blresourceName, "last_updated"),
+					resource.TestCheckResourceAttr(blResourceName, "name", blName),
+					resource.TestCheckResourceAttr(blResourceName, "upstream", blUrl),
+					resource.TestCheckResourceAttr(blResourceName, "override_to_allow.0", blOverride[0]),
+					resource.TestCheckResourceAttr(blResourceName, "override_to_allow.1", blOverride[1]),
+					resource.TestCheckResourceAttrSet(blResourceName, "id"),
+					resource.TestCheckResourceAttrSet(blResourceName, "last_updated"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      blresourceName,
+				ResourceName:      blResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				// The last_updated attribute does not exist in the HashiCups
@@ -48,19 +49,39 @@ func TestDNSBlockListResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: getDNSBlockListConfig(blresourceName, blNameChange, blUrlChange, blOverrideChange),
+				Config: getDNSBlockListConfig(blResourceName, blNameChange, blUrlChange, blOverrideChange),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(blresourceName, "name", blNameChange),
-					resource.TestCheckResourceAttr(blresourceName, "upstream", blUrlChange),
-					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.0", blOverrideChange[0]),
-					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.1", blOverrideChange[1]),
-					resource.TestCheckResourceAttr(blresourceName, "override_to_allow.2", blOverrideChange[2]),
-					resource.TestCheckResourceAttrSet(blresourceName, "id"),
-					resource.TestCheckResourceAttrSet(blresourceName, "last_updated"),
+					resource.TestCheckResourceAttr(blResourceName, "name", blNameChange),
+					resource.TestCheckResourceAttr(blResourceName, "upstream", blUrlChange),
+					resource.TestCheckResourceAttr(blResourceName, "override_to_allow.0", blOverrideChange[0]),
+					resource.TestCheckResourceAttr(blResourceName, "override_to_allow.1", blOverrideChange[1]),
+					resource.TestCheckResourceAttr(blResourceName, "override_to_allow.2", blOverrideChange[2]),
+					resource.TestCheckResourceAttrSet(blResourceName, "id"),
+					resource.TestCheckResourceAttrSet(blResourceName, "last_updated"),
 				),
 			},
 		},
 	})
+}
+
+func TestAccDNSBlockListResourceRecreation(t *testing.T) {
+	utils.RecreationTest(
+		t,
+		blResourceName,
+		getDNSBlockListConfig(blResourceName, blName, blUrl, blOverride),
+		deleteDNSBlockListResources,
+	)
+}
+
+// Delete all DNS blocklist resources from the API.
+func deleteDNSBlockListResources() {
+	client, _ := utils.NewEnvClient()
+
+	// Pretty simple blanket statement to just remove everything.
+	blocklists, _ := client.GetDNSBlockLists()
+	for id := range blocklists {
+		client.DeleteDNSBlockList(id)
+	}
 }
 
 func getDNSBlockListConfig(resource string, name string, url string, overrides []string) string {

--- a/internal/bowtie/test/dns_test.go
+++ b/internal/bowtie/test/dns_test.go
@@ -226,7 +226,7 @@ func deleteDNSResources() {
 	// Pretty simple blanket statement to just remove everything.
 	dnss, _ := client.GetDNS()
 	for id := range dnss {
-		client.DeleteDNS(id)
+		_ = client.DeleteDNS(id)
 	}
 }
 

--- a/internal/bowtie/test/dns_test.go
+++ b/internal/bowtie/test/dns_test.go
@@ -1,10 +1,13 @@
 package test
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"text/template"
 
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/client"
 	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -207,6 +210,62 @@ func TestAccDNSResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+// An acceptance test to confirm that the resource can be created,
+// then deleted out-of-band underneath the provider, then re-applied
+// and successfully recreate the resource without erroring out.
+func TestAccDNSResourceRecreation(t *testing.T) {
+	// Re-use this step later:
+	create := resource.TestStep{
+		Config: getDNSConfig("example.com", []string{"1.1.1.1"}, []string{}, nil),
+		ConfigPlanChecks: resource.ConfigPlanChecks{
+			PreApply: []plancheck.PlanCheck{
+				plancheck.ExpectResourceAction("bowtie_dns.test", plancheck.ResourceActionCreate),
+			},
+			PostApplyPostRefresh: []plancheck.PlanCheck{
+				plancheck.ExpectEmptyPlan(),
+			},
+		},
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("bowtie_dns.test", "name", "example.com"),
+			resource.TestCheckResourceAttr("bowtie_dns.test", "servers.0.addr", "1.1.1.1"),
+			resource.TestCheckResourceAttrSet("bowtie_dns.test", "id"),
+			resource.TestCheckResourceAttrSet("bowtie_dns.test", "last_updated"),
+		),
+	}
+
+	recreate := create
+	recreate.PreConfig = deleteDNSResources
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// First, create the resource normally and confirm that no
+			// pending changes remain and that the resource is consistent:
+			create,
+			// Then re-run the same configuration after deleting the
+			// resource from underneath terrform:
+			recreate,
+		},
+	})
+}
+
+// Delete all DNS resources from the API.
+func deleteDNSResources() {
+	username := os.Getenv("BOWTIE_USERNAME")
+	password := os.Getenv("BOWTIE_PASSWORD")
+
+	c, err := client.NewClient("http://127.0.0.1:3000", username, password, false)
+	if err != nil {
+		fmt.Println("Couldn't create Bowtie client")
+	}
+
+	// Pretty simple blanket statement to just remove everything.
+	dnss, _ := c.GetDNS()
+	for id, _ := range dnss {
+		c.DeleteDNS(id)
+	}
 }
 
 func getDNSConfig(name string, servers, excludes, sites []string) string {

--- a/internal/bowtie/test/group_test.go
+++ b/internal/bowtie/test/group_test.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -49,6 +50,26 @@ func TestGroupResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccGroupRecreation(t *testing.T) {
+	utils.RecreationTest(
+		t,
+		groupResourceName,
+		getGroupConfig(groupResourceName, groupName),
+		deleteGroupResources,
+	)
+}
+
+// Delete all group resources from the API.
+func deleteGroupResources() {
+	client, _ := utils.NewEnvClient()
+
+	// Pretty simple blanket statement to just remove everything.
+	groups, _ := client.GetGroups()
+	for id := range groups {
+		client.DeleteGroup(id)
+	}
 }
 
 func getGroupConfig(resource string, name string) string {

--- a/internal/bowtie/test/group_test.go
+++ b/internal/bowtie/test/group_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	groupResourceName = "bowtie_group.test"
+
+	groupName       = "My Group"
+	groupNameChange = "My Renamed Group"
+)
+
+func TestGroupResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Basic tests for groups
+			{
+				Config: getGroupConfig(groupResourceName, groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(groupResourceName, "name", groupName),
+					resource.TestCheckResourceAttrSet(groupResourceName, "id"),
+					resource.TestCheckResourceAttrSet(groupResourceName, "last_updated"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      groupResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The last_updated attribute does not exist in the HashiCups
+				// API, therefore there is no value for it during import.
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+			// Update and Read testing
+			{
+				Config: getGroupConfig(groupResourceName, groupNameChange),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(groupResourceName, "name", groupNameChange),
+					resource.TestCheckResourceAttrSet(groupResourceName, "id"),
+					resource.TestCheckResourceAttrSet(groupResourceName, "last_updated"),
+				),
+			},
+		},
+	})
+}
+
+func getGroupConfig(resource string, name string) string {
+	funcMap := template.FuncMap{
+		"notNil": func(val any) bool {
+			return val != nil
+		},
+	}
+
+	tmpl, err := template.New("").Funcs(funcMap).ParseGlob("testdata/*.tmpl")
+	if err != nil {
+		return ""
+	}
+
+	var output *strings.Builder = &strings.Builder{}
+	err = tmpl.ExecuteTemplate(output, "group.tmpl", map[string]interface{}{
+		"provider": provider.ProviderConfig,
+		"resource": strings.Split(resource, ".")[1],
+		"name":     name,
+	})
+
+	if err != nil {
+		panic("Failed to render template")
+	}
+
+	return output.String()
+}

--- a/internal/bowtie/test/group_test.go
+++ b/internal/bowtie/test/group_test.go
@@ -68,7 +68,7 @@ func deleteGroupResources() {
 	// Pretty simple blanket statement to just remove everything.
 	groups, _ := client.GetGroups()
 	for id := range groups {
-		client.DeleteGroup(id)
+		_ = client.DeleteGroup(id)
 	}
 }
 

--- a/internal/bowtie/test/organization_test.go
+++ b/internal/bowtie/test/organization_test.go
@@ -77,12 +77,10 @@ func getOrganizationConfig(resource string, name string, domain string) string {
 
 func getOrgId() resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
-		ctx := context.Background()
-
 		username := os.Getenv("BOWTIE_USERNAME")
 		password := os.Getenv("BOWTIE_PASSWORD")
 
-		client, err := client.NewClient(ctx, "http://localhost:3000", username, password, false)
+		client, err := client.NewClient("http://localhost:3000", username, password, false)
 
 		if err != nil {
 			return "", err

--- a/internal/bowtie/test/organization_test.go
+++ b/internal/bowtie/test/organization_test.go
@@ -1,14 +1,12 @@
 package test
 
 import (
-	"context"
-	"os"
 	"strings"
 	"testing"
 	"text/template"
 
-	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/client"
 	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -77,10 +75,7 @@ func getOrganizationConfig(resource string, name string, domain string) string {
 
 func getOrgId() resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
-		username := os.Getenv("BOWTIE_USERNAME")
-		password := os.Getenv("BOWTIE_PASSWORD")
-
-		client, err := client.NewClient("http://localhost:3000", username, password, false)
+		client, err := utils.NewEnvClient()
 
 		if err != nil {
 			return "", err

--- a/internal/bowtie/test/site_range_test.go
+++ b/internal/bowtie/test/site_range_test.go
@@ -78,10 +78,10 @@ func deleteSiteRangeResources() {
 
 	for _, site := range sites {
 		for _, siteRange := range site.RoutableRangesV4 {
-			client.DeleteSiteRange(site.ID, siteRange.ID)
+			_ = client.DeleteSiteRange(site.ID, siteRange.ID)
 		}
 		for _, siteRange := range site.RouteRangesV6 {
-			client.DeleteSiteRange(site.ID, siteRange.ID)
+			_ = client.DeleteSiteRange(site.ID, siteRange.ID)
 		}
 	}
 }

--- a/internal/bowtie/test/site_test.go
+++ b/internal/bowtie/test/site_test.go
@@ -56,6 +56,6 @@ func deleteSiteResources() {
 	// Pretty simple blanket statement to just remove everything.
 	sites, _ := client.GetSites()
 	for _, site := range sites {
-		client.DeleteSite(site.ID)
+		_ = client.DeleteSite(site.ID)
 	}
 }

--- a/internal/bowtie/test/site_test.go
+++ b/internal/bowtie/test/site_test.go
@@ -4,8 +4,15 @@ import (
 	"testing"
 
 	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+const siteConfig = provider.ProviderConfig + `
+resource "bowtie_site" "test" {
+  name = "Test Site"
+}
+`
 
 func TestAccSiteResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -13,11 +20,7 @@ func TestAccSiteResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: provider.ProviderConfig + `
-resource "bowtie_site" "test" {
-  name = "Test Site"
-}
-`,
+				Config: siteConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("bowtie_site.test", "name", "Test Site"),
 					resource.TestCheckResourceAttrSet("bowtie_site.test", "id"),
@@ -35,4 +38,24 @@ resource "bowtie_site" "test" {
 			},
 		},
 	})
+}
+
+func TestAccSiteRecreation(t *testing.T) {
+	utils.RecreationTest(
+		t,
+		"bowtie_site.test",
+		siteConfig,
+		deleteSiteResources,
+	)
+}
+
+// Delete all site resources from the API.
+func deleteSiteResources() {
+	client, _ := utils.NewEnvClient()
+
+	// Pretty simple blanket statement to just remove everything.
+	sites, _ := client.GetSites()
+	for _, site := range sites {
+		client.DeleteSite(site.ID)
+	}
 }

--- a/internal/bowtie/test/testdata/group.tmpl
+++ b/internal/bowtie/test/testdata/group.tmpl
@@ -1,0 +1,5 @@
+{{ .provider }}
+
+resource "bowtie_group" "{{ .resource }}" {
+  name = "{{ .name }}"
+}

--- a/internal/bowtie/test/user_sweeper_test.go
+++ b/internal/bowtie/test/user_sweeper_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -13,11 +12,11 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-func getBowtieClient(ctx context.Context, host string) (*client.Client, error) {
+func getBowtieClient(host string) (*client.Client, error) {
 	username := os.Getenv("BOWTIE_USERNAME")
 	password := os.Getenv("BOWTIE_PASSWORD")
 
-	c, err := client.NewClient(ctx, host, username, password, false)
+	c, err := client.NewClient(host, username, password, false)
 	return c, err
 
 }

--- a/internal/bowtie/test/user_sweeper_test.go
+++ b/internal/bowtie/test/user_sweeper_test.go
@@ -1,22 +1,11 @@
 package test
 
 import (
-	"os"
 	"testing"
 
-	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
-}
-
-func getBowtieClient(host string) (*client.Client, error) {
-	username := os.Getenv("BOWTIE_USERNAME")
-	password := os.Getenv("BOWTIE_PASSWORD")
-
-	c, err := client.NewClient(host, username, password, false)
-	return c, err
-
 }

--- a/internal/bowtie/test/user_test.go
+++ b/internal/bowtie/test/user_test.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/utils"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
@@ -15,9 +16,9 @@ import (
 func init() {
 	resource.AddTestSweepers("user", &resource.Sweeper{
 		Name: "user",
-		F: func(host string) error {
+		F: func(_ string) error {
 			ctx := context.Background()
-			client, err := getBowtieClient(host)
+			client, err := utils.NewEnvClient()
 			if err != nil {
 				return err
 			}

--- a/internal/bowtie/test/user_test.go
+++ b/internal/bowtie/test/user_test.go
@@ -17,7 +17,7 @@ func init() {
 		Name: "user",
 		F: func(host string) error {
 			ctx := context.Background()
-			client, err := getBowtieClient(ctx, host)
+			client, err := getBowtieClient(host)
 			if err != nil {
 				return err
 			}

--- a/internal/bowtie/test/user_test.go
+++ b/internal/bowtie/test/user_test.go
@@ -33,7 +33,7 @@ func init() {
 				}
 
 				if user.Role == "Owner" {
-					_, err := client.UpsertUser(ctx, user.ID, "", "", "User", false, false, false, false, false)
+					_, err := client.UpsertUser(user.ID, "", "", "User", false, false, false, false, false)
 					if err != nil {
 						fmt.Println("[Error] Failed to demote user")
 						continue

--- a/internal/bowtie/utils/testing.go
+++ b/internal/bowtie/utils/testing.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/client"
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func NewEnvClient() (*client.Client, error) {
+	host := os.Getenv("BOWTIE_HOST")
+	username := os.Getenv("BOWTIE_USERNAME")
+	password := os.Getenv("BOWTIE_PASSWORD")
+
+	c, err := client.NewClient(host, username, password, false)
+	return c, err
+}
+
+// An acceptance test to confirm that the resource can be created,
+// then deleted out-of-band underneath the provider, then re-applied
+// and successfully recreate the resource without erroring out.
+func RecreationTest(t *testing.T, resourceName string, config string, teardown func()) {
+	// Re-use this step later:
+	create := resource.TestStep{
+		Config: config,
+		ConfigPlanChecks: resource.ConfigPlanChecks{
+			PreApply: []plancheck.PlanCheck{
+				plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+			},
+			PostApplyPostRefresh: []plancheck.PlanCheck{
+				plancheck.ExpectEmptyPlan(),
+			},
+		},
+	}
+
+	recreate := create
+	recreate.PreConfig = teardown
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// First, create the resource normally and confirm that no
+			// pending changes remain and that the resource is consistent:
+			create,
+			// Then re-run the same configuration after deleting the
+			// resource from underneath terraform:
+			recreate,
+		},
+	})
+}

--- a/justfile
+++ b/justfile
@@ -61,6 +61,21 @@ site-id:
 		echo "SITE_ID=$(uuidgen)" >> $conf
 	fi
 
+# Ensure that the BOWTIE_HOST env var is set
+bowtie-host:
+	#!/usr/bin/env bash
+
+	conf={{envvars}}
+	var=BOWTIE_HOST
+	if grep $var $conf &>/dev/null
+	then
+		echo "$var present in $conf"
+	else
+		port=$(yq -r '.services.bowtie.ports[0] | split(":")[0]' < compose.yaml)
+		set -x
+		echo "$var=http://127.0.0.1:$port" >> $conf
+	fi
+
 # Generate an init-users file for bootstrapping
 init-users:
 	#!/usr/bin/env bash
@@ -91,7 +106,7 @@ image-var:
 		yq -i -Y --arg image "${image}" '.services.bowtie.image = $image' compose.yaml
 
 # Start a background container for bowtie-server
-container cmd=container_cmd: site-id init-users image-var
+container cmd=container_cmd: site-id init-users image-var bowtie-host
 	{{cmd}} up --detach
 
 # Stop the background container


### PR DESCRIPTION
This is a follow-up to #18 which cleans up those changes, extends them to all resource types, and additionally makes modest steps to "remember" IDs when recreations potentially occur.

In #18 this was done by swallowing errors emitted when reading resources from the API. With this PR, I moved up the read methods from the client one layer up into the resource code in order to be able to distinguish between 1) API-level errors, that is, if the response outright fails, versus 2) if the resource _itself_ is missing, for example, if the ID in question doesn't show up from a `GET`. In the former case, we still fail, but the latter case now sees the resource isn't there any more and clears the state to trigger a re-`Create`.  _(This is consistent behavior with most of the providers I looked into; for example, AWS EC2 and Linode both behave this way: if a resource "disappears", they clear state and re-trigger `Create`)_.

Those changes moved from filtering for "is this thing there?" into `resources/` instead of `client/`, but it wasn't a huge change.

The other changes here make a small tweak by checking if the plan doesn't have an ID, and **if** it doesn't, generates a UUID and then calls an `Upsert` normally. This (maybe?) should help support the first case described here so that - for example - if the API is temporarily inconsistent or unavailable, you'll just `POST` an `upsert` with the same resource information and it shouldn't duplicate API objects. This is less heavily tested since the use case is so intricate, but even if it doesn't hold onto the ID in the plan, the create-a-UUID-when-needed behavior should still be the same.

To ensure I didn't cause havoc, I wrote some tests for the `group` resource since it didn't have any.

In future work, we should mirror this "create on missing" behavior to the resources that have per-resource API endpoints. Right now, I _think_ the only resources that does this is `user` - all the others just list out resources and pluck the relevant ID out of the list. This probably requires fiddling with `doRequest` since we'll need to handle 404s a little differently when getting users by ID, although this merits more careful attention since it looks like some of that behavior may be coded into the user resource since it's already kind of forgiving for empty user responses.

/cc @chriskuchin