### PR TITLE
Update resources location schema to work with new API

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,4 +67,5 @@ provider "bowtie" {
 - `host` (String) The Bowtie HTTP Controller endpoint. Honors the `BOWTIE_HOST` environment variable if set. Example: `https://bowtie.example.com`
 - `lazy_authentication` (Boolean) By default, the provider will authenticate to the Bowtie API just in time (or lazily) which permits use cases like creating Controllers in Terraform before using their API endpoints. Set this variable to `false` if you instead want to authenticate at the time the provider is configured - for example, to catch authentication errors up-front before starting an `apply` or `plan`.
 - `password` (String, Sensitive) Administrator password login credentials. Honors the `BOWTIE_PASSWORD` environment variable if set
+- `tagged_locations` (Boolean) Control whether the provider will send policy resource locations using the new tagged type format or legacy format.
 - `username` (String) Administrator username/email login credentials. Honors the `BOWTIE_USERNAME` environment variable if set

--- a/internal/bowtie/client/http.go
+++ b/internal/bowtie/client/http.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Client struct {
-	HTTPClient *http.Client
+	HTTPClient       *http.Client
+	Tagged_locations bool
 
 	hostURL   string
 	auth      AuthPayload
@@ -25,7 +26,7 @@ type AuthPayload struct {
 
 const apiVersionPrefix = "/-net/api/v0"
 
-func NewClient(host, username, password string, lazy_auth bool) (*Client, error) {
+func NewClient(host, username, password string, lazy_auth bool, tagged_locations bool) (*Client, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return nil, err
@@ -38,7 +39,8 @@ func NewClient(host, username, password string, lazy_auth bool) (*Client, error)
 				return http.ErrUseLastResponse
 			},
 		},
-		hostURL: host,
+		Tagged_locations: tagged_locations,
+		hostURL:          host,
 		auth: AuthPayload{
 			Username: username,
 			Password: password,

--- a/internal/bowtie/resources/resource.go
+++ b/internal/bowtie/resources/resource.go
@@ -321,7 +321,7 @@ func (r *resourceResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	resp.Diagnostics.Append(req.State.Set(ctx, plan)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *resourceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/bowtie/test/resource_test.go
+++ b/internal/bowtie/test/resource_test.go
@@ -1,0 +1,129 @@
+package test
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/provider"
+	"github.com/bowtieworks/terraform-provider-bowtie/internal/bowtie/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestAccBowtieResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: getBowtieConfig(
+					"Internal web",
+					"http",
+					map[string]string{
+						"cidr": "10.0.0.0/16",
+					},
+					map[string][]int{
+						"collection": {80, 443},
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("bowtie_resource.test", "name", "Internal web"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "protocol", "http"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "location.cidr", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "ports.collection.0", "80"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "ports.collection.1", "443"),
+				),
+			},
+			{
+				Config: getBowtieConfig(
+					"Internal web changed",
+					"all",
+					map[string]string{
+						"dns": "test.example.com",
+					},
+					map[string][]int{
+						"range": {0, 65535},
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("bowtie_resource.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("bowtie_resource.test", "name", "Internal web changed"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "protocol", "all"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "location.dns", "test.example.com"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "ports.range.0", "0"),
+					resource.TestCheckResourceAttr("bowtie_resource.test", "ports.range.1", "65535"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBowtieResourceRecreation(t *testing.T) {
+	utils.RecreationTest(
+		t,
+		"bowtie_resource.test",
+		getBowtieConfig(
+			"Testing",
+			"all",
+			map[string]string{
+				"ip": "192.168.1.1",
+			},
+			map[string][]int{
+				"collection": {80},
+			},
+		),
+		deleteBowtieResources,
+	)
+}
+
+// Delete all Bowtie resources from the API.
+func deleteBowtieResources() {
+	client, _ := utils.NewEnvClient()
+
+	// Pretty simple blanket statement to just remove everything.
+	resources, _ := client.GetResources()
+	for id := range resources {
+		_ = client.DeleteResource(id)
+	}
+}
+
+func getBowtieConfig(name string, protocol string, locations map[string]string, ports map[string][]int) string {
+	funcMap := template.FuncMap{
+		"notNil": func(val any) bool {
+			return val != nil
+		},
+	}
+
+	tmpl, err := template.New("").Funcs(funcMap).ParseGlob("testdata/*.tmpl")
+	if err != nil {
+		return ""
+	}
+
+	var output *strings.Builder = &strings.Builder{}
+	err = tmpl.ExecuteTemplate(output, "resource.tmpl", map[string]interface{}{
+		"provider":  provider.ProviderConfig,
+		"name":      name,
+		"protocol":  protocol,
+		"locations": locations,
+		"ports":     ports,
+	})
+	if err != nil {
+		panic("Failed to render template")
+	}
+
+	return output.String()
+}

--- a/internal/bowtie/test/testdata/resource.tmpl
+++ b/internal/bowtie/test/testdata/resource.tmpl
@@ -1,0 +1,22 @@
+{{ .provider }}
+resource "bowtie_resource" "test" {
+  name = "{{ .name }}"
+
+  protocol = "{{ .protocol }}"
+
+  {{- range $kind, $location := .locations }}
+  location = {
+    {{ $kind }} = "{{ $location }}"
+  }
+  {{ end -}}
+
+  {{- range $kind, $ports := .ports }}
+  ports = {
+    {{ $kind }} = [
+      {{- range $port := $ports }}
+      {{ $port -}},
+      {{ end -}}
+    ]
+  }
+  {{ end -}}
+}

--- a/internal/bowtie/utils/testing.go
+++ b/internal/bowtie/utils/testing.go
@@ -15,7 +15,7 @@ func NewEnvClient() (*client.Client, error) {
 	username := os.Getenv("BOWTIE_USERNAME")
 	password := os.Getenv("BOWTIE_PASSWORD")
 
-	c, err := client.NewClient(host, username, password, false)
+	c, err := client.NewClient(host, username, password, false, true)
 	return c, err
 }
 


### PR DESCRIPTION
Two main changes here:

- Tests for `bowtie_resource`. This was missing before and doing so, uh, found a bug :sweat_smile: so I fixed that bug alongside the new tests.
- Adds a `tagged_locations` configuration file to the `bowtie { }` providers stanza that defaults to `true`. This will signal the HTTP client to use the different `location` format for policy resources, i.e. send `{"type": "dns", "value": "example.com"}` rather than `{"dns": "example.com"}`.

  These changes try and make the code _kind_ of smart by trying to parse either/or format, depending on what the API sends back, so the code should work with _either_ API format. Left a TODO to remove the duplicate paths once the API is sufficiently sunset.

/cc @chriskuchin