### PR TITLE
Fix acceptance tests, ensure to disable users before destroy

### DIFF
--- a/internal/bowtie/client/http.go
+++ b/internal/bowtie/client/http.go
@@ -87,10 +87,21 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 400 {
+		ct := res.Header.Get("Content-Type")
+		snippet := string(body)
+		if len(snippet) > 4096 {
+			snippet = snippet[:4096] + "…[truncated]"
+		}
+		return nil, fmt.Errorf("HTTP %d %s (%s): %s",
+			res.StatusCode, http.StatusText(res.StatusCode), ct, strings.TrimSpace(snippet))
 	}
 
 	return body, nil

--- a/internal/bowtie/client/resources.go
+++ b/internal/bowtie/client/resources.go
@@ -118,10 +118,6 @@ func (c *Client) UpsertResource(id, name, protocol string, location BowtieResour
 		return BowtieResource{}, err
 	}
 
-	if err != nil {
-		return BowtieResource{}, err
-	}
-
 	req, err := http.NewRequest(http.MethodPost, c.getHostURL("/policy/upsert_resource"), bytes.NewBuffer(body))
 	if err != nil {
 		return BowtieResource{}, err

--- a/internal/bowtie/client/users.go
+++ b/internal/bowtie/client/users.go
@@ -55,7 +55,7 @@ func (c *Client) GetUserByEmail(ctx context.Context, email string) (BowtieUser, 
 func (c *Client) GetUser(id string) (BowtieUser, error) {
 	req, err := http.NewRequest(http.MethodGet, c.getHostURL(fmt.Sprintf("/user/%s", id)), nil)
 	if err != nil {
-		return BowtieUser{}, nil
+		return BowtieUser{}, err
 	}
 
 	body, err := c.doRequest(req)

--- a/internal/bowtie/resources/user.go
+++ b/internal/bowtie/resources/user.go
@@ -162,7 +162,7 @@ func (u *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed creating user",
-			"Unexpected error craeting the user: "+err.Error(),
+			"Unexpected error creating the user: "+err.Error(),
 		)
 		return
 	}

--- a/internal/bowtie/resources/user.go
+++ b/internal/bowtie/resources/user.go
@@ -183,6 +183,7 @@ func (u *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 			"Failed reading the user: "+state.ID.ValueString(),
 			"Unexpected error reading the user: "+err.Error(),
 		)
+		return
 	}
 
 	state.Name = types.StringValue(user.Name)

--- a/internal/bowtie/test/group_membership_test.go
+++ b/internal/bowtie/test/group_membership_test.go
@@ -15,7 +15,7 @@ func TestAccGroupMembershipResource(t *testing.T) {
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: getGroupMembershipConfig(),
+				Config: getGroupMembershipConfig(true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
@@ -27,11 +27,20 @@ func TestAccGroupMembershipResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("bowtie_group_membership.admin_memberships", "group_id"),
 				),
 			},
+			{
+				Config: getGroupMembershipConfig(false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 		},
 	})
 }
 
-func getGroupMembershipConfig() string {
+func getGroupMembershipConfig(enabled bool) string {
 	funcMap := template.FuncMap{
 		"notNil": func(val any) bool {
 			return val != nil
@@ -45,6 +54,7 @@ func getGroupMembershipConfig() string {
 
 	var output *strings.Builder = &strings.Builder{}
 	err = tmpl.ExecuteTemplate(output, "group_membership.tmpl", map[string]interface{}{
+		"enabled":  enabled,
 		"provider": provider.ProviderConfig,
 	})
 	if err != nil {

--- a/internal/bowtie/test/group_membership_test.go
+++ b/internal/bowtie/test/group_membership_test.go
@@ -53,7 +53,7 @@ func getGroupMembershipConfig(enabled bool) string {
 	}
 
 	var output *strings.Builder = &strings.Builder{}
-	err = tmpl.ExecuteTemplate(output, "group_membership.tmpl", map[string]interface{}{
+	err = tmpl.ExecuteTemplate(output, "group_membership.tmpl", map[string]any{
 		"enabled":  enabled,
 		"provider": provider.ProviderConfig,
 	})

--- a/internal/bowtie/test/testdata/group_membership.tmpl
+++ b/internal/bowtie/test/testdata/group_membership.tmpl
@@ -1,17 +1,20 @@
 {{ .provider }}
-resource "bowtie_user" "jane" {
-  name = "Jane Doe"
-  email = "jane.doe@example.com"
+resource "bowtie_user" "billy" {
+  name = "Billy Doe"
+  email = "billy.doe@example.com"
+  enabled = "{{ .enabled }}"
 }
 
 resource "bowtie_user" "john" {
   name = "John Doe"
   email = "john.doe@example.com"
+  enabled = "{{ .enabled }}"
 }
 
 resource "bowtie_user" "logan" {
   name = "Logan"
   email = "logan@example.com"
+  enabled = "{{ .enabled }}"
 }
 
 resource "bowtie_group" "admins" {
@@ -21,7 +24,7 @@ resource "bowtie_group" "admins" {
 resource "bowtie_group_membership" "admin_memberships" {
   group_id = bowtie_group.admins.id
   users = [
-    bowtie_user.jane.id,
+    bowtie_user.billy.id,
     bowtie_user.logan.id,
     bowtie_user.john.id,
   ]

--- a/internal/bowtie/test/testdata/user.tmpl
+++ b/internal/bowtie/test/testdata/user.tmpl
@@ -2,6 +2,7 @@
 resource "bowtie_user" "user" {
   name = "{{ .name }}"
   email = "{{ .email }}"
+  enabled = "{{ .enabled }}"
 
 {{ if ne .role "" }}
   role = "{{.role}}"

--- a/internal/bowtie/test/user_test.go
+++ b/internal/bowtie/test/user_test.go
@@ -63,7 +63,7 @@ func TestAccUserResource(t *testing.T) {
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: getUserConfig("Jane Doe", "jane.doe@example.com", "", false, false, false, false, false),
+				Config: getUserConfig("Jane Doe", "jane.doe@example.com", "", false, false, false, false, false, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
@@ -83,7 +83,7 @@ func TestAccUserResource(t *testing.T) {
 				),
 			},
 			{
-				Config: getUserConfig("Jane Doe", "jane.doe@example.com", "Owner", true, true, true, true, true),
+				Config: getUserConfig("Jane Doe", "jane.doe@example.com", "Owner", true, true, true, true, true, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
@@ -103,7 +103,7 @@ func TestAccUserResource(t *testing.T) {
 				),
 			},
 			{
-				Config: getUserConfig("Jane Doe", "jane.doe@example.com", "User", true, false, false, false, false),
+				Config: getUserConfig("Jane Doe", "jane.doe@example.com", "User", true, false, false, false, false, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
@@ -122,11 +122,31 @@ func TestAccUserResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("bowtie_user.user", "id"),
 				),
 			},
+			{
+				Config: getUserConfig("Jane Doe", "jane.doe@example.com", "User", true, false, false, false, false, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("bowtie_user.user", "name", "Jane Doe"),
+					resource.TestCheckResourceAttr("bowtie_user.user", "email", "jane.doe@example.com"),
+					resource.TestCheckResourceAttr("bowtie_user.user", "role", "User"),
+					resource.TestCheckResourceAttr("bowtie_user.user", "enabled", "false"),
+					resource.TestCheckResourceAttr("bowtie_user.user", "authz_devices", "false"),
+					resource.TestCheckResourceAttr("bowtie_user.user", "authz_policies", "false"),
+					resource.TestCheckResourceAttr("bowtie_user.user", "authz_control_plane", "false"),
+					resource.TestCheckResourceAttr("bowtie_user.user", "authz_users", "false"),
+					resource.TestCheckResourceAttrSet("bowtie_user.user", "id"),
+				),
+			},
 		},
 	})
 }
 
-func getUserConfig(name, email, role string, authz, authz_users, authz_devices, authz_policies, authz_control_plane bool) string {
+func getUserConfig(name, email, role string, authz, authz_users, authz_devices, authz_policies, authz_control_plane bool, enabled bool) string {
 	funcMap := template.FuncMap{
 		"notNil": func(val any) bool {
 			return val != nil
@@ -149,6 +169,7 @@ func getUserConfig(name, email, role string, authz, authz_users, authz_devices, 
 		"authz_policies":      authz_policies,
 		"authz_users":         authz_users,
 		"authz_control_plane": authz_control_plane,
+		"enabled":             enabled,
 	})
 	if err != nil {
 		panic("Failed to render template")

--- a/internal/bowtie/test/user_test.go
+++ b/internal/bowtie/test/user_test.go
@@ -43,7 +43,7 @@ func init() {
 
 				err = client.DisableUser(ctx, user.ID)
 				if err != nil {
-					fmt.Println("[Error] failed to disble user")
+					fmt.Println("[Error] failed to disable user")
 					continue
 				}
 

--- a/internal/bowtie/test/user_test.go
+++ b/internal/bowtie/test/user_test.go
@@ -159,7 +159,7 @@ func getUserConfig(name, email, role string, authz, authz_users, authz_devices, 
 	}
 
 	var output *strings.Builder = &strings.Builder{}
-	err = tmpl.ExecuteTemplate(output, "user.tmpl", map[string]interface{}{
+	err = tmpl.ExecuteTemplate(output, "user.tmpl", map[string]any{
 		"provider":            provider.ProviderConfig,
 		"name":                name,
 		"email":               email,


### PR DESCRIPTION
Tests are failing because we don't disable users in the tests before destroying them. I also caught a lot of lint errors, typos, and invisibly-swallowed errors while debugging the disable problems.