### PR TITLE
Cleanup miscellaneous errors or missed error checking

### DIFF
--- a/internal/bowtie/client/resources.go
+++ b/internal/bowtie/client/resources.go
@@ -170,7 +170,7 @@ func (c *Client) GetPolicy(id string) (BowtiePolicy, error) {
 func (c *Client) GetResourceGroups() (map[string]BowtieResourceGroup, error) {
 	rp, err := c.GetPoliciesAndResources()
 	if err != nil {
-		return make(map[string]BowtieResourceGroup), nil
+		return nil, err
 	}
 
 	return rp.ResourceGroups, nil

--- a/internal/bowtie/data_sources/user.go
+++ b/internal/bowtie/data_sources/user.go
@@ -113,10 +113,10 @@ func (u *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	state.Name = types.StringValue(user.Name)
 	state.Status = types.StringValue(user.Status)
 
-	state.AuthzControlPlane = types.BoolValue(*user.AuthzControlPlane)
-	state.AuthzDevices = types.BoolValue(*user.AuthzDevices)
-	state.AuthzPolicies = types.BoolValue(*user.AuthzPolicies)
-	state.AuthzUsers = types.BoolValue(*user.AuthzUsers)
+	state.AuthzControlPlane = types.BoolPointerValue(user.AuthzControlPlane)
+	state.AuthzDevices = types.BoolPointerValue(user.AuthzDevices)
+	state.AuthzPolicies = types.BoolPointerValue(user.AuthzPolicies)
+	state.AuthzUsers = types.BoolPointerValue(user.AuthzUsers)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/internal/bowtie/resources/dns.go
+++ b/internal/bowtie/resources/dns.go
@@ -248,6 +248,7 @@ func (d *dnsResource) Create(ctx context.Context, req resource.CreateRequest, re
 			"Failed talking to bowtie server",
 			"Unexpected error creating dns setting: "+err.Error(),
 		)
+		return
 	}
 
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
@@ -334,14 +335,15 @@ func (d *dnsResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return state.DNS64Exclude[i].Order.ValueInt64() < state.DNS64Exclude[j].Order.ValueInt64()
 	})
 
-	var includeSites []string
-	resp.Diagnostics.Append(state.IncludeOnlySites.ElementsAs(ctx, &includeSites, false)...)
+	state.Name = types.StringValue(dns.Name)
+	includeSites, diags := types.ListValueFrom(ctx, types.StringType, dns.IncludeOnlySites)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.IncludeOnlySites = includeSites
 
-	state.Name = types.StringValue(dns.Name)
-
+	state.IsDNS64 = types.BoolValue(dns.IsDNS64)
 	state.IsCounted = types.BoolValue(dns.IsCounted)
 	state.IsDropA = types.BoolValue(dns.IsDropA)
 	state.IsDropAll = types.BoolValue(dns.IsDropAll)

--- a/internal/bowtie/resources/dns_block_list.go
+++ b/internal/bowtie/resources/dns_block_list.go
@@ -190,9 +190,17 @@ func (bl *dnsBlockListResource) Read(ctx context.Context, req resource.ReadReque
 	state.Name = types.StringValue(blocklist.Name)
 	state.Upstream = types.StringValue(blocklist.Upstream)
 
-	overrides, diags := types.ListValueFrom(
-		ctx, types.StringType, strings.Split(blocklist.OverrideToAllow, "\n"),
-	)
+	rawOverrides := blocklist.OverrideToAllow
+	overrideEntries := []string{}
+	if strings.TrimSpace(rawOverrides) != "" {
+		for _, entry := range strings.Split(rawOverrides, "\n") {
+			if trimmed := strings.TrimSpace(entry); trimmed != "" {
+				overrideEntries = append(overrideEntries, trimmed)
+			}
+		}
+	}
+
+	overrides, diags := types.ListValueFrom(ctx, types.StringType, overrideEntries)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/bowtie/resources/group.go
+++ b/internal/bowtie/resources/group.go
@@ -94,6 +94,7 @@ func (g *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 			"Error creating group",
 			"Could not create the group, unexpected error: "+err.Error(),
 		)
+		return
 	}
 
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))

--- a/internal/bowtie/resources/group_membership.go
+++ b/internal/bowtie/resources/group_membership.go
@@ -171,5 +171,5 @@ func (g *GroupMembershipResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func (g *GroupMembershipResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resource.ImportStatePassthroughID(ctx, path.Root("group_id"), req, resp)
 }

--- a/internal/bowtie/resources/resource.go
+++ b/internal/bowtie/resources/resource.go
@@ -158,10 +158,18 @@ func (r *resourceResource) Create(ctx context.Context, req resource.CreateReques
 	var portsCollection []int64
 	if !plan.Ports.Range.IsNull() {
 		portsRange = []int64{}
-		plan.Ports.Range.ElementsAs(ctx, &portsRange, true)
+		diags := plan.Ports.Range.ElementsAs(ctx, &portsRange, true)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	} else if !plan.Ports.Collection.IsNull() {
 		portsCollection = []int64{}
-		plan.Ports.Collection.ElementsAs(ctx, &portsCollection, true)
+		diags := plan.Ports.Collection.ElementsAs(ctx, &portsCollection, true)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	} else {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("ports"),
@@ -344,10 +352,18 @@ func (r *resourceResource) Update(ctx context.Context, req resource.UpdateReques
 	var portsCollection []int64
 	if !plan.Ports.Range.IsNull() {
 		portsRange = []int64{}
-		plan.Ports.Range.ElementsAs(ctx, &portsRange, true)
+		diags := plan.Ports.Range.ElementsAs(ctx, &portsRange, true)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	} else if !plan.Ports.Collection.IsNull() {
 		portsCollection = []int64{}
-		plan.Ports.Collection.ElementsAs(ctx, &portsCollection, true)
+		diags := plan.Ports.Collection.ElementsAs(ctx, &portsCollection, true)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	} else {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("ports"),

--- a/internal/bowtie/resources/site.go
+++ b/internal/bowtie/resources/site.go
@@ -158,7 +158,7 @@ func (s *siteResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (s *siteResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var state groupResourceModel
+	var state siteResourceModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/bowtie/resources/site_range.go
+++ b/internal/bowtie/resources/site_range.go
@@ -242,12 +242,19 @@ func (sr *siteRangeResource) Update(ctx context.Context, req resource.UpdateRequ
 	var is_ipv4 bool
 	var is_ipv6 bool
 	var cidr string
-	if !(plan.IPV4Range.IsNull() && plan.IPV4Range.IsUnknown()) {
+	if !plan.IPV4Range.IsUnknown() && !plan.IPV4Range.IsNull() {
 		is_ipv4 = true
 		cidr = plan.IPV4Range.ValueString()
-	} else if !(plan.IPV6Range.IsNull() && plan.IPV6Range.IsUnknown()) {
+	} else if !plan.IPV6Range.IsUnknown() && !plan.IPV6Range.IsNull() {
 		is_ipv6 = true
 		cidr = plan.IPV6Range.ValueString()
+	} else {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("ipv4_range"),
+			"Missing range information",
+			"Expected either ipv4_range or ipv6_range to be configured in plan.",
+		)
+		return
 	}
 
 	err := sr.client.UpsertSiteRange(plan.SiteID.ValueString(), plan.ID.ValueString(), plan.Name.ValueString(), plan.Description.ValueString(), cidr, is_ipv4, is_ipv6, plan.Weight.ValueInt64(), plan.Metric.ValueInt64())

--- a/internal/bowtie/resources/user.go
+++ b/internal/bowtie/resources/user.go
@@ -192,10 +192,10 @@ func (u *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	state.Enabled = types.BoolValue(user.Status == "Active")
 
-	state.AuthzControlPlane = types.BoolValue(*user.AuthzControlPlane)
-	state.AuthzDevices = types.BoolValue(*user.AuthzDevices)
-	state.AuthzPolicies = types.BoolValue(*user.AuthzPolicies)
-	state.AuthzUsers = types.BoolValue(*user.AuthzUsers)
+	state.AuthzControlPlane = types.BoolPointerValue(user.AuthzControlPlane)
+	state.AuthzDevices = types.BoolPointerValue(user.AuthzDevices)
+	state.AuthzPolicies = types.BoolPointerValue(user.AuthzPolicies)
+	state.AuthzUsers = types.BoolPointerValue(user.AuthzUsers)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }


### PR DESCRIPTION
While debugging the broken integration/acceptance tests I found that we're silently swallowing errors in a few places that really exacerbated the debugging process. There's several places where we can actually bubble up errors and catch bad responses, so this makes those changes. Shouldn't break anything, just make errors more obvious.